### PR TITLE
Use OpenSSL instead of nettle for hash, rand, enc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,8 @@ endif()
 if(LIBPWSAFE_BUILD_TESTS)
     find_package(GTest REQUIRED)
 endif()
-pkg_check_modules(NETTLE REQUIRED nettle)
+find_package(OpenSSL REQUIRED)
 
-CHECK_INCLUDE_FILES("sys/random.h" HAVE_SYS_RANDOM_H)
 CHECK_FUNCTION_EXISTS("getpwuid" HAVE_PWUID)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/config.h")
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,3 +1,2 @@
 #cmakedefine LIBPWSAFE_VERSION "@LIBPWSAFE_VERSION@"
-#cmakedefine HAVE_SYS_RANDOM_H
 #cmakedefine HAVE_PWUID

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,11 +4,11 @@ list(APPEND SRC
     util.c
 )
 add_library(objlib OBJECT ${SRC})
-target_include_directories(objlib PUBLIC ${NETTLE_INCLUDE_DIRS})
+target_include_directories(objlib PUBLIC ${OPENSSL_INCLUDE_DIR})
 
 if(LIBPWSAFE_BUILD_STATIC)
     add_library(pwsafeStatic STATIC)
-    target_link_libraries(pwsafeStatic PUBLIC pwsafe_api objlib INTERFACE nettle)
+    target_link_libraries(pwsafeStatic PUBLIC pwsafe_api objlib INTERFACE OpenSSL::Crypto)
 
     # On Windows, static lib is libpwsafe.lib, DLL is pwsafe.dll/.lib
     # On Linux, static lib is libpwsafe.a, SO is libpwsafe.so
@@ -25,7 +25,7 @@ endif()
 
 if(LIBPWSAFE_BUILD_SHARED)
     add_library(pwsafe SHARED)
-    target_link_libraries(pwsafe PRIVATE objlib PUBLIC pwsafe_api ${NETTLE_LINK_LIBRARIES})
+    target_link_libraries(pwsafe PRIVATE objlib PUBLIC pwsafe_api OpenSSL::Crypto)
 
     set_target_properties(pwsafe 
         PROPERTIES 
@@ -47,5 +47,5 @@ if(CMAKE_PROJECT_NAME STREQUAL "libpwsafe")
     set(CPACK_RPM_PACKAGE_LICENSE "GPL-3.0-only" PARENT_SCOPE)
 endif()
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.35-0ubuntu3.1), libnettle8 (>= 3.7.3-1build2)" PARENT_SCOPE)
-set(CPACK_RPM_PACKAGE_REQUIRES "glibc >= 2.36, nettle >= 3.8" PARENT_SCOPE)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.35-0ubuntu3.1), libssl3 (>= 3.0.0)" PARENT_SCOPE)
+set(CPACK_RPM_PACKAGE_REQUIRES "glibc >= 2.36, openssl-libs >= 3.0.0" PARENT_SCOPE)

--- a/src/db.c
+++ b/src/db.c
@@ -7,10 +7,7 @@
 #include <stdbool.h>
 #include <ctype.h>
 #include <unistd.h>
-#ifdef HAVE_SYS_RANDOM_H
-#include <sys/random.h>
-#endif
-#include <nettle/sha2.h>
+#include <openssl/rand.h>
 
 // IMB 2023-01-01 Most of the code here is
 // adapted from code by Nicolas Dade https://github.com/nsd20463/pwsafe
@@ -134,30 +131,31 @@ static void generate_hash(Block input, uint8_t output[SHA1_DIGEST_SIZE], const c
 {
     // generate test hash from random and passphrase
     // I am mystified as to why Bruce uses these extra 2 zero bytes in the hashes
-    struct sha1_ctx sha_ctx;
-    sha1_init(&sha_ctx);
-    sha1_update(&sha_ctx, BLOCK_SIZE, input);
+    SHA_CTX sha_ctx;
+    SHA1_Init(&sha_ctx);
+    SHA1_Update(&sha_ctx, input, BLOCK_SIZE);
     static const unsigned char zeros[2] = {0, 0};
-    sha1_update(&sha_ctx, sizeof(zeros), zeros);
+    SHA1_Update(&sha_ctx, zeros, sizeof(zeros));
     size_t pw_len = strlen(pw);
-    sha1_update(&sha_ctx, pw_len, (const uint8_t *)pw);
+    SHA1_Update(&sha_ctx, (const uint8_t *)pw, pw_len);
     unsigned char key[SHA1_DIGEST_SIZE];
-    sha1_digest(&sha_ctx, sizeof(key), key);
+    SHA1_Final(key, &sha_ctx);
 
-    struct blowfish_ctx bf_ctx;
-    blowfish_set_key(&bf_ctx, sizeof(key), key);
+    BF_KEY bf_ctx;
+    BF_set_key(&bf_ctx, sizeof(key), key);
 
     Block block;
     memcpy(&block, input, BLOCK_SIZE);
 
-    // For nettle to match OpenSSL we must swap byte order before and after encrypt
+    // We must swap byte order before and after encrypt to mimic passwordsafe,
+    // which assumes little-endian i386 while Blowfish operates on big-endian words
     // TODO: test this on a big-endian machine
     swap_byte_order(block);
 
     // to mimic passwordsafe I use BF_encrypt() directly, but that means I have to pretend that I am on a little-endian
     // machine b/c passwordsafe assumes a i386
     for (int i = 0; i < 1000; ++i)
-        blowfish_encrypt(&bf_ctx, BLOCK_SIZE, (uint8_t *)&block, (const uint8_t *)&block);
+        BF_ecb_encrypt((const uint8_t *)&block, (uint8_t *)&block, &bf_ctx, BF_ENCRYPT);
 
     swap_byte_order(block);
 
@@ -170,11 +168,12 @@ static void generate_hash(Block input, uint8_t output[SHA1_DIGEST_SIZE], const c
     // The good thing is we are hashing something which is already well hashed, so I doubt this
     // opened up any holes. But it does show that one should always step the program in a debugger
     // and watch what the variables are doing; sometimes it is eye opening!
-    sha1_init(&sha_ctx);
-    memset_func(sha_ctx.state, 0, sizeof(sha_ctx.state));
-    sha1_update(&sha_ctx, BLOCK_SIZE, (const uint8_t *)block);
-    sha1_update(&sha_ctx, sizeof(zeros), zeros);
-    sha1_digest(&sha_ctx, SHA1_DIGEST_SIZE, output);
+    SHA1_Init(&sha_ctx);
+    // Zero the SHA1 state (h0..h4) to replicate the passwordsafe bug described above
+    sha_ctx.h0 = sha_ctx.h1 = sha_ctx.h2 = sha_ctx.h3 = sha_ctx.h4 = 0;
+    SHA1_Update(&sha_ctx, (const uint8_t *)block, BLOCK_SIZE);
+    SHA1_Update(&sha_ctx, zeros, sizeof(zeros));
+    SHA1_Final(output, &sha_ctx);
 
     memset_func(key, 0, sizeof(key));
     memset_func(&bf_ctx, 0, sizeof(bf_ctx));
@@ -182,11 +181,7 @@ static void generate_hash(Block input, uint8_t output[SHA1_DIGEST_SIZE], const c
 
 static inline _Bool generate_random(uint8_t *buf, size_t len)
 {
-#ifdef HAVE_SYS_RANDOM_H
-    return getrandom(buf, len, GRND_NONBLOCK) == (ssize_t)len;
-#else
-  #error Function generate_random undefined
-#endif
+    return RAND_bytes(buf, (int)len) == 1;
 }
 
 /**
@@ -262,7 +257,7 @@ void db_decode_block(PwsDb *pdb, Block block)
     // is because the blowfish implementation used in the original passwordsafe
     // operated on assumed little-endian 32-bit ints and not arrays of bytes
     swap_byte_order(block);
-    blowfish_decrypt(&pdb->bf_ctx, BLOCK_SIZE, (uint8_t *)block, (const uint8_t *)block);
+    BF_ecb_encrypt((const uint8_t *)block, (uint8_t *)block, &pdb->bf_ctx, BF_DECRYPT);
     swap_byte_order(block);
 
     const uint8_t *cbc = pdb->cbc;
@@ -284,7 +279,7 @@ void db_encode_block(PwsDb *pdb, Block block)
     }
 
     swap_byte_order(block);
-    blowfish_encrypt(&pdb->bf_ctx, BLOCK_SIZE, (uint8_t *)block, (const uint8_t *)block);
+    BF_ecb_encrypt((const uint8_t *)block, (uint8_t *)block, &pdb->bf_ctx, BF_ENCRYPT);
     swap_byte_order(block);
 
     memcpy(pdb->cbc, block, BLOCK_SIZE);
@@ -758,14 +753,14 @@ static void db_compute_key(PwsDb *pdb, const char *pw)
 {
     Header *h = &pdb->db_header;
     memcpy(pdb->cbc, h->iv, sizeof(pdb->cbc));
-    struct sha1_ctx ctx;
-    sha1_init(&ctx);
+    SHA_CTX ctx;
+    SHA1_Init(&ctx);
     size_t pw_len = strlen(pw);
-    sha1_update(&ctx, pw_len, (const uint8_t *)pw);
-    sha1_update(&ctx, sizeof(h->salt), h->salt);
+    SHA1_Update(&ctx, (const uint8_t *)pw, pw_len);
+    SHA1_Update(&ctx, h->salt, sizeof(h->salt));
     uint8_t key[SHA1_DIGEST_SIZE];
-    sha1_digest(&ctx, sizeof(key), key);
-    blowfish_set_key(&pdb->bf_ctx, sizeof(key), key);
+    SHA1_Final(key, &ctx);
+    BF_set_key(&pdb->bf_ctx, sizeof(key), key);
 }
 
 /** Sanity checks */

--- a/src/pwsafe_priv.h
+++ b/src/pwsafe_priv.h
@@ -3,8 +3,9 @@
 #define HAVE_PWSAFE_PRIV_H
 
 #include "config.h"
-#include <nettle/sha1.h>
-#include <nettle/blowfish.h>
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
+#include <openssl/blowfish.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -13,6 +14,11 @@
 #ifdef __cplusplus
 extern "C"
 {
+#endif
+
+// Nettle exposed this macro; OpenSSL calls it SHA_DIGEST_LENGTH
+#ifndef SHA1_DIGEST_SIZE
+#define SHA1_DIGEST_SIZE SHA_DIGEST_LENGTH
 #endif
 
 // Prevent memset from being optimized out
@@ -54,7 +60,7 @@ typedef struct PwsDb
     FILE *db_file;
     Header db_header;
     PWSAFE_DB_VERSION db_vers;
-    struct blowfish_ctx bf_ctx;
+    BF_KEY bf_ctx;
     Block cbc;  // Always little-endian
 } PwsDb;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,6 @@ target_link_libraries(
     pwsafeStatic
     GTest::gtest_main
 )
-target_link_directories(libpwsafe-test PRIVATE ${NETTLE_LIBRARY_DIRS})
 # TODO IMB 2024-07-29 Copy test resources after build
 #add_custom_target(
 #    TARGET libpwsafe-test POST_BUILD
@@ -16,4 +15,4 @@ target_link_directories(libpwsafe-test PRIVATE ${NETTLE_LIBRARY_DIRS})
 include(GoogleTest)
 gtest_discover_tests(libpwsafe-test WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/../test")
 
-# add_test("unit tests" COMMAND libpwsafe-test)
+# add_test(NAME "unit tests" COMMAND libpwsafe-test)

--- a/test/test.cc
+++ b/test/test.cc
@@ -79,12 +79,12 @@ TEST(Test, BlockEncodeDecodeSucceeds)
     uint8_t cbc[8] = {'1','2','3','4','5','6','7','8'};
 
     memset(&pdb.bf_ctx, 0, sizeof(pdb.bf_ctx));
-    blowfish_set_key(&pdb.bf_ctx, sizeof(key), (uint8_t *)key);
+    BF_set_key(&pdb.bf_ctx, sizeof(key), key);
     memcpy(pdb.cbc, cbc, 8);
     db_encode_block(&pdb, block);
 
     memset(&pdb.bf_ctx, 0, sizeof(pdb.bf_ctx));
-    blowfish_set_key(&pdb.bf_ctx, sizeof(key), (uint8_t *)key);
+    BF_set_key(&pdb.bf_ctx, sizeof(key), key);
     memcpy(pdb.cbc, cbc, 8);
     db_decode_block(&pdb, block);
 


### PR DESCRIPTION
Replace nettle and random number generators with OpenSSL